### PR TITLE
Strip leading stars from comment lines before unindenting the comment

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -736,7 +736,7 @@ YUI.add('doc-builder', function(Y) {
                                         i.paramsList.push(name);
                                     });
                                 }
-                                i.methodDescription = self._parseCode(markdown(i.description));
+                                i.methodDescription = self._parseCode(markdown(i.description || ''));
                                 if (i.example && i.example.length) {
                                     if (i.example.forEach) {
                                         var e = '';

--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -906,34 +906,24 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
          * parsers.
          */
         handlecomment: function(comment, file, line) {
-            comment = this.unindent(comment);
-
             var lines = comment.split(REGEX_LINES),
                 len = lines.length, i,
                 parts, part, peek, skip,
-                hasStars = true,
                 results = [{tag: 'file', value: file},
                            {tag: 'line', value: line}],
-                linefix = /^\s*\*\s?/;
+                starRegex = /^\s*\*/,
+                hasStars  = lines[0] && starRegex.test(lines[0]);
 
-            if (lines[1] && (lines[1].indexOf('*') === -1)) {
-                hasStars = false;
-            }
-
-// trim leading space and *, preserve the rest of the white space
-            for (i = 0; i < len; i++) {
-                if (hasStars) {
-                    lines[i] = lines[i].replace(linefix, ' ');
-                }
-                //TODO This needs to be fixed. This assumes that a ' ' preceeds all @ tags
-                if (lines[i].substring(1) !== ' ') {
-                    lines[i] = ' ' + lines[i];
+// trim leading stars if there are any
+            if (hasStars) {
+                for (i = 0; i < len; i++) {
+                    lines[i] = lines[i].replace(starRegex, '');
                 }
             }
 
 // reconsitute and tokenize the comment block
-            comment = lines.join('\n');
-            parts = comment.split(/ (@\w*)/);
+            comment = this.unindent(lines.join('\n'));
+            parts = comment.split(/(@\w*)/);
             len = parts.length;
             for (i = 0; i < len; i++) {
                 value = '';

--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -46,7 +46,7 @@ YUI.add('docparser', function(Y) {
     * @return {String} The modified string
     */
     implodeString = function(str) {
-        return str.replace(REGEX_GLOBAL_LINES, '!~YUIDOC_LINE~!')
+        return str.replace(REGEX_GLOBAL_LINES, '!~YUIDOC_LINE~!');
     },
     /*
     * Un-flatted a string, replace tokens injected with `implodeString`
@@ -56,7 +56,7 @@ YUI.add('docparser', function(Y) {
     * @return {String} The modified string
     */
     explodeString = function(str) {
-        return str.replace(/!~YUIDOC_LINE~!/g, '\n')
+        return str.replace(/!~YUIDOC_LINE~!/g, '\n');
     },
     CURRENT_NAMESPACE = 'currentnamespace',
     CURRENT_MODULE = 'currentmodule',
@@ -466,7 +466,7 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
         'const': function(tagname, value, target, block) {
             target.itemtype = property;
             target.name = value;
-            target.final = ''
+            target['final'] = '';
         },
 
         // supported classitems


### PR DESCRIPTION
This ensures that, whether comments have leading stars or not, the final indentation level of the comment is always normalized to zero and Markdown lists and formatting markup (which use stars) are always parsed
properly.
