### PR TITLE
Use native JSON instead of Y.JSON

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -860,6 +860,9 @@ YUI.add('doc-builder', function(Y) {
                                 break;
                         }
                     });
+
+                    opts.meta.attrs.sort(self.nameSort);
+                    opts.meta.events.sort(self.nameSort);
                     opts.meta.methods.sort(self.nameSort);
                     opts.meta.properties.sort(self.nameSort);
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -17,7 +17,7 @@ YUI.add('doc-builder', function(Y) {
 
     var print = function(items) {
         var out = '<ul>';
-        
+
         Y.each(items, function(i, k) {
             out += '<li>';
             if (Y.Lang.isObject(i)) {
@@ -405,7 +405,7 @@ YUI.add('doc-builder', function(Y) {
             return o;
         },
         /**
-        * Makes the default directories needed 
+        * Makes the default directories needed
         * @method makeDirs
         * @param {Callback} cb The callback to execute after it's completed
         */
@@ -449,7 +449,7 @@ YUI.add('doc-builder', function(Y) {
         */
         _inlineCode: function(html) {
             html = html.replace(/\\`/g, '__{{SELLECK_BACKTICK}}__');
-            
+
             html = html.replace(/`(.+?)`/g, function (match, code) {
                 return '<code>' + Y.escapeHTML(code) + '</code>';
             });
@@ -459,7 +459,7 @@ YUI.add('doc-builder', function(Y) {
             return html;
         },
         /**
-        * Ported from [Selleck](https://github.com/rgrove/selleck)  
+        * Ported from [Selleck](https://github.com/rgrove/selleck)
         Renders the handlebars templates with the default View class.
         * @method render
         * @param {HTML} source The default template to parse
@@ -493,8 +493,8 @@ YUI.add('doc-builder', function(Y) {
             if (!TEMPLATE) {
                 TEMPLATE = handlebars.compile(layout);
             }
-            
-            
+
+
             var _v = {};
             for (var k in view) {
                 if (Y.Lang.isFunction(view[k])) {
@@ -504,7 +504,7 @@ YUI.add('doc-builder', function(Y) {
                 }
             };
             html = TEMPLATE(_v);
-            
+
             html = this._inlineCode(html);
             callback(null, html);
         },
@@ -649,7 +649,7 @@ YUI.add('doc-builder', function(Y) {
         writeClasses: function(cb) {
             var self = this;
             var stack = new Y.Parallel();
-            
+
             Y.log('Writing (' + Object.keys(self.data.classes).length + ') class pages', 'info', 'builder');
             Y.each(self.data.classes, function(v) {
                 Y.prepare(themeDir, self.getProjectMeta(), function(err, opts) {
@@ -718,7 +718,7 @@ YUI.add('doc-builder', function(Y) {
                             i.returnType = i.return.type;
                         }
                         //console.error(i);
-                        opts.meta.is_constructor = [i]; 
+                        opts.meta.is_constructor = [i];
                     }
 
                     classItems.forEach(function(i) {
@@ -803,10 +803,17 @@ YUI.add('doc-builder', function(Y) {
 
                                 opts.meta.properties.push(i);
                                 break;
-                            case 'attribute':
+
+                            case 'attribute': // fallthru
+                            case 'config':
                                 i = self.augmentData(i);
-                                i.emit = self.options.attributesEmit;
                                 i.attrDescription = self._parseCode(markdown(i.description || ''));
+
+                                if (i.itemtype === 'config') {
+                                    i.config = true;
+                                } else {
+                                    i.emit = self.options.attributesEmit;
+                                }
 
                                 if (i.example && i.example.length) {
                                     if (i.example.forEach) {
@@ -923,7 +930,7 @@ YUI.add('doc-builder', function(Y) {
         writeFiles: function(cb) {
             var self = this;
             var stack = new Y.Parallel();
-            
+
             Y.log('Writing (' + Object.keys(self.data.files).length + ') source files', 'info', 'builder');
             Y.each(self.data.files, function(v) {
                 Y.prepare(themeDir, self.getProjectMeta(), function(err, opts) {
@@ -942,7 +949,7 @@ YUI.add('doc-builder', function(Y) {
                     opts = self.populateClasses(opts);
                     opts = self.populateModules(opts);
                     opts = self.populateFiles(opts);
-                    
+
                     opts.meta.fileName = v.name;
                     Y.Files.readFile((v.path || v.name), encoding='utf8', stack.add(Y.rbind(function(err, data, opts, v) {
                         opts.meta.fileData = data;
@@ -963,10 +970,10 @@ YUI.add('doc-builder', function(Y) {
         },
         /**
         * Normalizes a file path to a writable filename:
-        * 
+        *
         *    var path = 'lib/file.js';
         *    returns 'lib_file.js';
-        * 
+        *
         * @method filterFileName
         * @param {String} f The filename to normalize
         * @return {String} The filtered file path

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -808,6 +808,18 @@ YUI.add('doc-builder', function(Y) {
                                 i.emit = self.options.attributesEmit;
                                 i.attrDescription = self._parseCode(markdown(i.description || ''));
 
+                                if (i.example && i.example.length) {
+                                    if (i.example.forEach) {
+                                        var e = '';
+                                        i.example.forEach(function(v) {
+                                            e += self._parseCode(markdown(v));
+                                        });
+                                        i.example = e;
+                                    } else {
+                                        i.example = self._parseCode(markdown(i.example));
+                                    }
+                                }
+
                                 // If this item is provided by a module other
                                 // than the module that provided the original
                                 // class, add the original module name to the
@@ -822,6 +834,18 @@ YUI.add('doc-builder', function(Y) {
                             case 'event':
                                 i = self.augmentData(i);
                                 i.eventDescription = self._parseCode(markdown(i.description || ''));
+
+                                if (i.example && i.example.length) {
+                                    if (i.example.forEach) {
+                                        var e = '';
+                                        i.example.forEach(function(v) {
+                                            e += self._parseCode(markdown(v));
+                                        });
+                                        i.example = e;
+                                    } else {
+                                        i.example = self._parseCode(markdown(i.example));
+                                    }
+                                }
 
                                 // If this item is provided by a module other
                                 // than the module that provided the original

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -759,6 +759,16 @@ YUI.add('doc-builder', function(Y) {
                                     i.hasReturn = true;
                                     i.returnType = i.return.type;
                                 }
+
+                                // If this item is provided by a module other
+                                // than the module that provided the original
+                                // class, add the original module name to the
+                                // item's `providedBy` property so we can
+                                // indicate the relationship.
+                                if ((i.submodule || i.module) !== (v.submodule || v.module)) {
+                                    i.providedBy = (i.submodule || i.module);
+                                }
+
                                 opts.meta.methods.push(i);
                                 break;
                             case 'property':
@@ -781,17 +791,47 @@ YUI.add('doc-builder', function(Y) {
                                         i.example = self._parseCode(markdown(i.example));
                                     }
                                 }
+
+                                // If this item is provided by a module other
+                                // than the module that provided the original
+                                // class, add the original module name to the
+                                // item's `providedBy` property so we can
+                                // indicate the relationship.
+                                if ((i.submodule || i.module) !== (v.submodule || v.module)) {
+                                    i.providedBy = (i.submodule || i.module);
+                                }
+
                                 opts.meta.properties.push(i);
                                 break;
                             case 'attribute':
                                 i = self.augmentData(i);
                                 i.emit = self.options.attributesEmit;
                                 i.attrDescription = self._parseCode(markdown(i.description || ''));
+
+                                // If this item is provided by a module other
+                                // than the module that provided the original
+                                // class, add the original module name to the
+                                // item's `providedBy` property so we can
+                                // indicate the relationship.
+                                if ((i.submodule || i.module) !== (v.submodule || v.module)) {
+                                    i.providedBy = (i.submodule || i.module);
+                                }
+
                                 opts.meta.attrs.push(i);
                                 break;
                             case 'event':
                                 i = self.augmentData(i);
                                 i.eventDescription = self._parseCode(markdown(i.description || ''));
+
+                                // If this item is provided by a module other
+                                // than the module that provided the original
+                                // class, add the original module name to the
+                                // item's `providedBy` property so we can
+                                // indicate the relationship.
+                                if ((i.submodule || i.module) !== (v.submodule || v.module)) {
+                                    i.providedBy = (i.submodule || i.module);
+                                }
+
                                 opts.meta.events.push(i);
                                 break;
                         }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -343,7 +343,7 @@ YUI.add('doc-builder', function(Y) {
         addFoundAt: function(a) {
             var self = this;
             if (a.file && a.line) {
-                a.foundAt = 'files/' + self.filterFileName(a.file) + '.html#LINE_' + a.line;
+                a.foundAt = 'files/' + self.filterFileName(a.file) + '.html#l' + a.line;
             }
             return a;
         },

--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -22,7 +22,7 @@ YUI.add('docparser', function(Y) {
     },
 
     /**
-    * Parses the JSON data and formats it into a nice log string for filename and line number:  
+    * Parses the JSON data and formats it into a nice log string for filename and line number:
     `/file/name.js:123`
     * @method stringlog
     * @private
@@ -79,10 +79,12 @@ YUI.add('docparser', function(Y) {
     REGEX_GLOBAL_LINES = /\r\n|\n/g,
 
     SHORT_TAGS = {
-        'final': 1,
-        'static': 1,
+        'async': 1,
+        'beta': 1,
+        'chainable': 1,
         'extends': 1,
-        'beta': 1
+        'final': 1,
+        'static': 1
     },
 
     /**
@@ -348,7 +350,7 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
         // can be used by anthing that has an optional {type} and a description
         'return': function(tagname, value, target, block) {
 
-            var desc = implodeString(trim(value)), type, 
+            var desc = implodeString(trim(value)), type,
                 match = REGEX_TYPE.exec(desc),
                 result = {};
             if (match) {
@@ -498,7 +500,7 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
             if (!Lang.isArray(target[tagname])) {
                 target[tagname] = [];
             }
-            
+
             //target[tagname].push(this.unindent(trim(value)));
             target[tagname].push(value);
         },
@@ -506,18 +508,16 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
             if (!Lang.isArray(target[tagname])) {
                 target[tagname] = [];
             }
-            
+
             var e = value;
             block.forEach(function(v) {
                 if (v.tag == 'example') {
                     e = v.value;
                 }
             });
-            
+
             target[tagname].push(e);
         },
-        'author': 'todo',
-        'contributor': 'todo',
         'url': 'todo',
         'icon': 'todo',
         'see': 'todo',
@@ -527,6 +527,22 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
         'optional': 'todo',
         'uses': 'todo',
         'category': 'todo',
+
+        genericValueTag: function (tagname, value, target, block) {
+            target[tagname] = value;
+        },
+
+        'author'     : 'genericValueTag',
+        'contributor': 'genericValueTag',
+        'since'      : 'genericValueTag',
+
+        'deprecated': function (tagname, value, target, block) {
+            target.deprecated = true;
+
+            if (typeof value === 'string' && value.length) {
+                target.deprecationMessage = value;
+            }
+        },
 
         // updates the current namespace
         'namespace': function(tagname, value, target, block) {
@@ -762,7 +778,7 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
                         is_submodule: 1,
                         namespaces: {}
                     };
-                    
+
                     mod.module = this.get(CURRENT_MODULE);
                     mod.namespace = this.get(CURRENT_NAMESPACE);
                 }
@@ -771,7 +787,7 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
             }
         },
         lastclass: {
-            
+
         },
         /**
          * The class currently being parsed
@@ -891,7 +907,7 @@ Y.log('param name/type/descript missing: ' + stringlog(block), 'warn', 'docparse
         @return {String} Unindented text.
         @private
         **/
-        
+
         unindent: function(content) {
             var indent = content.match(/^(\s+)/);
 

--- a/lib/docparser.js
+++ b/lib/docparser.js
@@ -11,11 +11,16 @@ YUI.add('docparser', function(Y) {
     * @return {String} The fixed string
     */
     fixType = function(t) {
-        if (t.substring(0, 1) !== t.substring(0, 1).toUpperCase()) {
-            t = t.substring(0, 1).toUpperCase() + t.substring(1);
+        var firstChar      = t.charAt(0),
+            upperFirstChar = firstChar.toUpperCase();
+
+        if (firstChar !== upperFirstChar) {
+            return upperFirstChar + t.substring(1);
         }
+
         return t;
     },
+
     /**
     * Parses the JSON data and formats it into a nice log string for filename and line number:  
     `/file/name.js:123`

--- a/lib/yuidoc.js
+++ b/lib/yuidoc.js
@@ -191,7 +191,7 @@ YUI.add('yuidoc', function(Y) {
                 out = fs.createWriteStream(file, {
                         flags: "w", encoding: "utf8", mode: 0644
                 });
-                out.write(Y.JSON.stringify(parser.data, null, 4));
+                out.write(JSON.stringify(parser.data, null, 4));
                 out.end();
             }
 


### PR DESCRIPTION
Y.JSON currently has two bugs that make it suck in yuidoc:

  1) It doesn't use the native JSON object in Node.js, even though it
     should. This makes it slooooow.
  2) It sporadically adds indentation _inside_ key names, for some
     reason I haven't been able to identify.
