### PR TITLE
Fixed issue with Markdown processing of overridden examples.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -467,6 +467,8 @@ YUI.add('doc-builder', function(Y) {
                         if (k === 'description' || k === 'example') {
                             if (k1 === 'return') {
                                 o[k1][k] = markdown(v, true, self.defaultReturnTags);
+                            } else if (v.forEach || (v instanceof Object)) {
+                                o[k1][k] = self.augmentData(v);
                             } else {
                                 o[k1][k] = markdown(v, true, self.defaultTags);
                             }


### PR DESCRIPTION
The `example` tag can be an array when the API docs for a method are
overridden by another class. To handle this case we loop over the value
_again_ if its an array or object.
