### PR TITLE
Fixed issue with resolving tabs' hash URLs when we shouldn't.

### DIFF
--- a/api/assets/js/api-list.js
+++ b/api/assets/js/api-list.js
@@ -91,7 +91,7 @@ inputNode.on('focus', function () {
 });
 
 // Update all tabview links to resolved URLs.
-tabview.get('contentBox').all('a').each(function (link) {
+tabview.get('panelNode').all('a').each(function (link) {
     link.setAttribute('href', link.get('href'));
 });
 

--- a/themes/default/assets/js/api-list.js
+++ b/themes/default/assets/js/api-list.js
@@ -91,7 +91,7 @@ inputNode.on('focus', function () {
 });
 
 // Update all tabview links to resolved URLs.
-tabview.get('contentBox').all('a').each(function (link) {
+tabview.get('panelNode').all('a').each(function (link) {
     link.setAttribute('href', link.get('href'));
 });
 


### PR DESCRIPTION
The URL resolving hack was also resolving the hash-based URLs for the
tabs which was unintended. The initial URL resolving is now scoped to
the tabview's `panelNode`.
