### PR TITLE
Fix a typo in document

### DIFF
--- a/docs/syntax/index.mustache
+++ b/docs/syntax/index.mustache
@@ -1,5 +1,5 @@
 <div class="intro">
-    <p>YUIDoc's syntax should be familar if you've used 
+    <p>YUIDoc's syntax should be familiar if you've used 
     Javadoc, JSDoc, Doxygen, or most other documentation generator tools. 
     YUIDoc relies on <dfn>tags</dfn> such as `@param` or `@return` embedded in comments blocks 
     that start with `/**` and end with `*/`. 


### PR DESCRIPTION
Small fix. It didn't change within `output/`, Please merge it and rebuild document.
